### PR TITLE
Remove noindex legal pages from sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,16 +6,4 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
-  <url>
-    <loc>https://ruehmland.de/impressum.html</loc>
-    <lastmod>2026-06-15</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://ruehmland.de/datenschutz.html</loc>
-    <lastmod>2026-05-06</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
 </urlset>


### PR DESCRIPTION
noindex + sitemap are conflicting signals. Drop impressum + datenschutz entries; homepage-only sitemap. Pages still discoverable via footer links.